### PR TITLE
add cloudpickle to hand custom preprocessor

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -4,3 +4,4 @@ scipy==1.5
 scikit-learn==0.21
 statsmodels==0.12
 xgboost==1.4
+cloudpickle>=1.3,<1.6


### PR DESCRIPTION
When using spline regression in a custom preprocessor, cloudpickle is necessary to run the custom view