### PR TITLE
downgrade Werkzeug to avoid custom webapp from crashing with python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.1] - Bugfix Release - 2022-04
+
+* Fixed package requirement dependency issue with python 3.7 for the custom view
+
 ## [Version 1.0.0] - Initial Release - 2022-03
 
 * GLM regression in the Visual ML

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn==0.21
 statsmodels==0.12
 xgboost==1.4
 cloudpickle>=1.3,<1.6
+Werkzeug<2.1.0

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,8 +1,7 @@
-dash==2.0
+dash==2.3.1
 dash_bootstrap_components==0.13
 scipy==1.5
 scikit-learn==0.21
 statsmodels==0.12
 xgboost==1.4
 cloudpickle>=1.3,<1.6
-Werkzeug<2.1.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "generalized-linear-models",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "meta": {
         "label": "Generalized Linear Models",
         "description": "Train and deploy Generalized Linear Models",


### PR DESCRIPTION
GLM Summary custom view was crashing when using python 3.7. Downgrading Werkzeug to version <2.1.0 fixes the issue and does not break for python 3.6.