### PR TITLE
set plotly version

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn==0.21
 statsmodels==0.12
 xgboost==1.4
 cloudpickle>=1.3,<1.6
+plotly==5.13.0


### PR DESCRIPTION
plotly is used in the plugin and pulled through the dash dependency. However dash requires plotly>=5.0.0. The recent plotly version (https://github.com/plotly/plotly.py/releases/tag/v5.13.1) requires the package packaging but it is not added in its requirements. To avoid any issues, the plotly version is set to latest working one: 5.13.0.