### PR TITLE
Chore/dss12 python update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.3] - Upgrade Release - 2023-05
+
+* Update code env description to support python versions 3.7, 3.8, 3.9, and 3.10
+
 ## [Version 1.0.2] - Bugfix Release - 2022-07
 
 * Fixed binary classification prediction output format to fit v11 stricter format

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Dataiku
+   Copyright 2022 - 2023 Dataiku
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile variables set automatically
-plugin_id=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
-plugin_version=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`
+plugin_id=`cat plugin.json | python3 -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
+plugin_version=`cat plugin.json | python3 -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`
 archive_file_name="dss-plugin-${plugin_id}-${plugin_version}.zip"
 remote_url=`git config --get remote.origin.url`
 last_commit_id=`git rev-parse HEAD`
@@ -21,8 +21,8 @@ plugin:
 unit-tests:
 	@echo "Running unit tests..."
 	@( \
-		PYTHON_VERSION=`python3 -V 2>&1 | sed 's/[^0-9]*//g' | cut -c 1,2`; \
-		PYTHON_VERSION_IS_CORRECT=`cat code-env/python/desc.json | python3 -c "import sys, json; print(str($$PYTHON_VERSION) in [x[-2:] for x in json.load(sys.stdin)['acceptedPythonInterpreters']]);"`; \
+		PYTHON_VERSION=`python3 -c "import sys; print('PYTHON{}{}'.format(sys.version_info.major, sys.version_info.minor))"`; \
+		PYTHON_VERSION_IS_CORRECT=`cat code-env/python/desc.json | python3 -c "import sys, json; print('$$PYTHON_VERSION' in json.load(sys.stdin)['acceptedPythonInterpreters']);"`; \
 		if [ $$PYTHON_VERSION_IS_CORRECT == "False" ]; then echo "Python version $$PYTHON_VERSION is not in acceptedPythonInterpreters"; exit 1; else echo "Python version $$PYTHON_VERSION is in acceptedPythonInterpreters"; fi; \
 	)
 	@( \

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,7 +1,12 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON37"],
+  "acceptedPythonInterpreters": [
+    "PYTHON36", 
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false,
-  "corePackagesSet": "PANDAS10"
+  "corePackagesSet": "AUTO"
 }

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,8 +1,12 @@
 dash==2.3.1
 dash_bootstrap_components==0.13
-scipy==1.5
-scikit-learn==0.21
-statsmodels==0.12
-xgboost==1.4
+scikit-learn>=0.21,<1.1
+scipy>=1.2,<1.3; python_version <= '3.7'
+scipy==1.5; python_version == '3.8'
+scipy==1.6; python_version == '3.9'
+scipy==1.10.1; python_version >= '3.10'
+statsmodels==0.12; python_version <= '3.9'
+statsmodels==0.13.5; python_version >= '3.10'
 cloudpickle>=1.3,<1.6
+xgboost==1.4
 plotly==5.13.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "generalized-linear-models",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "meta": {
         "label": "Generalized Linear Models",
         "description": "Train and deploy Generalized Linear Models",


### PR DESCRIPTION
Changed code env requirements to be compatible with python 3.6-3.10. No support for python 3.11, because it requires scikit-learn 1.1, not supported in visual ML.
For the custom view to work, the code env from the design environment should be compatible with the plugin env, or unpickling error occur.